### PR TITLE
Check if API directory exists before generating Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,14 @@ set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 
 set (CMAKE_SUPPRESS_REGENERATION 1)
 set (CMAKE_CONFIGURATION_TYPES Debug;Release;RelWithDebInfo)
-set (AC_API_DEVKIT_DIR $ENV{AC_API_DEVKIT_DIR} CACHE PATH "API DevKit directory.")
+
+if(EXISTS ${AC_API_DEVKIT_DIR})
+	message (STATUS "SDK Directory OK")
+	set (AC_API_DEVKIT_DIR $ENV{AC_API_DEVKIT_DIR} CACHE PATH "API DevKit directory.")
+else()
+	message (FATAL_ERROR "SDK Directory does not exist.\n Please check the value of the AC_API_DEVKIT_DIR variable.\n" $ENV{AC_API_DEVKIT_DIR})
+endif()
+
 set (AC_ADDON_NAME "ExampleAddOn" CACHE STRING "Add-On name.")
 set (AC_ADDON_LANGUAGE "INT" CACHE STRING "Add-On language code.")
 


### PR DESCRIPTION
One day I miss typed SDK Directory instead of "C:\" I forgot the backslash like "C:Program Files\". For some reason CMake Built the solution for Visual Studio but the Resource Compiler was giving errors. So I thought that it would be nice if CMake checks if directory exists before it builds.