### PR TITLE
Treat source files with .c extension as CPP files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,11 @@ else ()
 endif ()
 
 SetCompilerOptions (AddOn)
+file (GLOB AllCFiles
+	${AddOnSourcesFolder}/*.c
+)
+set_source_files_properties(${AllCFiles} PROPERTIES LANGUAGE CXX)
+
 file (GLOB ModuleFolders ${AC_API_DEVKIT_DIR}/Support/Modules/*)
 target_include_directories (AddOn PUBLIC ${ModuleFolders})
 if (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,10 +163,7 @@ else ()
 endif ()
 
 SetCompilerOptions (AddOn)
-file (GLOB AllCFiles
-	${AddOnSourcesFolder}/*.c
-)
-set_source_files_properties(${AllCFiles} PROPERTIES LANGUAGE CXX)
+set_source_files_properties(${AddOnSourceFiles} PROPERTIES LANGUAGE CXX)
 
 file (GLOB ModuleFolders ${AC_API_DEVKIT_DIR}/Support/Modules/*)
 target_include_directories (AddOn PUBLIC ${ModuleFolders})


### PR DESCRIPTION
CMake by default compiles source files with .c extension as pure C files.
We have to explicit set them to be handled as CPP files.

This modification solves issue #8 