### PR TITLE
Added a Private.hpp suitable for public repositories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Build/*
 .DS_Store
 .vscode
+Private.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,33 @@ function (SetCompilerOptions target)
 	endif ()
 endfunction ()
 
+# Generates the Private.hpp file
+function (GeneratePrivateHeader)
+set (PRIVATE_HPP_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/Sources/AddOn/Private.hpp")
+	if(EXISTS "${PRIVATE_HPP_LOCATION}")
+		MESSAGE(STATUS "Private.hpp already exists. \n ----------------Do not make this file public!----------------")
+	else()
+		MESSAGE(WARNING "Private.hpp doesn't exist.")
+		MESSAGE(STATUS "Creating Private.hpp at ${PRIVATE_HPP_LOCATION}")
+		FILE(WRITE ${PRIVATE_HPP_LOCATION} 
+			"/*\n"
+			"This file is added to the .gitignore file\n"
+			"DO NOT REMOVE IT FROM .gitignore, CONTAINS PERSONAL INFORMATION\n"
+			"Here you can store API Tokens, third party login informations etc.\n"
+			"*/\n"
+			"#ifndef PRIVATE_HPP\n"
+			"#define PRIVATE_HPP\n"
+			"\n"
+			"#define DEVELOPER_ID 1 /*Replace with developer ID*/\n"
+			"#define LOCAL_ID 1 /*Replace with local ID*/\n"
+			"#endif"
+		)
+
+	endif()
+	
+endfunction()
+
+
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 
 set (CMAKE_SUPPRESS_REGENERATION 1)
@@ -162,6 +189,7 @@ else ()
 	)
 endif ()
 
+GeneratePrivateHeader()
 SetCompilerOptions (AddOn)
 set_source_files_properties (${AddOnSourceFiles} PROPERTIES LANGUAGE CXX)
 

--- a/Sources/AddOnResources/RFIX/AddOnFix.grc
+++ b/Sources/AddOnResources/RFIX/AddOnFix.grc
@@ -1,6 +1,8 @@
+#include "Private.hpp"
+
 'MDID' 32500 "Add-On Identifier" {
-	1 /* Replace with your developer id. */
-	1 /* Replace with your local id. */
+	DEVELOPER_ID 
+	LOCAL_ID 
 }
 
 'GICN' 10001 "AddOnIcon" {


### PR DESCRIPTION
I had issues open-sourcing my repository based on this template. If I made the repo public everyone would have had access to my Developer ID and Local ID.
Because the AddOn relies on the AddOnFix.grc to build, it could not be added to the .gitignore. It forced me to make my repositories private. 

I had thought about the workflow this way:

1. The Developer ID and the Local ID is no longer located inside the AddOnFix.grc file, it pulls them from Private.hpp through an include statement.
2. I added the Private.hpp to .gitignore, this way it is not made public even if the repo is public.
3. When you CMake the project if the Private.hpp does not exist it generates one with the Local ID and Developer ID set to 1.
_This way the AddOn builds for Demo mode_

The Private.hpp should be shared via cloud, e-mail, etc. Even more important(at least for me) this way you can store credentials in it without having to share them.

This workflow is similar to my NodeJS environment, where the .env is a private file where I store my credentials.

