### PR TITLE
Fix conan version to 1.59.0 (close #14)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Get Conan
-      uses: turtlebrowser/get-conan@v1.0
+      uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 1.59.0
       
     - name: Create Conan default profile
       run: conan profile new default --detect

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endfunction ()
 
 set (API_DEVKIT_DIR $ENV{AC_API_DEVKIT_DIR})
 
-if (GITHUB_BUILD)
+if (NOT EXISTS ${API_DEVKIT_DIR})
 	include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
 	set (API_DEVKIT_DIR ${CONAN_ARCHICAD-APIDEVKIT_ROOT}/bin)
 endif ()

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains a CMake template for Archicad Add-On Development. You c
 
 - [CMake](https://cmake.org) (3.16 minimum version is needed).
 - [Python](https://www.python.org) for resource compilation (version 2.7+ or 3.8+).
-- [Conan](https://conan.io) for convenience.
+- [Conan](https://conan.io) for convenience (version 1.x).
 
 There are several possibilities to build this Add-On, using different IDEs, with downloaded Archicad API Development Kit or by using the Conan C++ package manager.
 
@@ -21,7 +21,7 @@ There are several possibilities to build this Add-On, using different IDEs, with
   - `AC_ADDON_NAME`: (optional) The name of the project file and the result binary Add-On file (default is "ExampleAddOn").
   - `AC_ADDON_LANGUAGE`: (optional) The language code of the Add-On (default is "INT").
   - `AC_MDID_DEV`: (optional) Your Developer ID. Omitting this will result in a 1 value.
-  - `AC_MDID_LOC`: (optional) Add-On Local ID. Omitting this will result in a 1 value. 
+  - `AC_MDID_LOC`: (optional) Add-On Local ID. Omitting this will result in a 1 value.
 - To release your Add-On you have to provide valid MDIDs.
 
 ### Visual Studio (Windows)
@@ -54,7 +54,7 @@ cd ..
 
 ## Build using the Conan Package Manager
 ### Prepare
-- [Download the package manager](https://conan.io/downloads.html)
+- [Download the package manager](https://conan.io/downloads.html), please install conan v1.x.
 - Run conan to create the default profile (use Command Prompt on Windows and Terminal on MacOS):
 
       conan profile new default --detect
@@ -95,11 +95,11 @@ cd ..
 - Open the root folder in Visual Studio Code, configure and build the solution.
 ## Archicad Compatibility
 
-This template is tested with all Archicad versions starting from Archicad 23 using the downloaded Archicad API Development Kit and starting fro Archicad 25 using Conan. 
+This template is tested with all Archicad versions starting from Archicad 23 using the downloaded Archicad API Development Kit and starting fro Archicad 25 using Conan.
 
 ## Use in Archicad
 
-To use the Add-On in Archicad, you have to add your compiled .apx file in Add-On Manager. The example Add-On registers a new command into the Options menu. Please note that the example Add-On works only in the demo version of Archicad. 
+To use the Add-On in Archicad, you have to add your compiled .apx file in Add-On Manager. The example Add-On registers a new command into the Options menu. Please note that the example Add-On works only in the demo version of Archicad.
 
 You can start Archicad in demo mode with the following command line commands:
 - Windows: `ARCHICAD.exe -DEMO`


### PR DESCRIPTION
1. Conan v2.0 introduces breaking changes, fix conan version to 1.59.0 to make the action work.
2. Fix README
2. Always set `API_DEVKIT_DIR` when it is not specified as an environment variable.

close #14 