### PR TITLE
Build with AC28 in CI as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os-type: [ windows-2022, macos-13 ]
-        ac-version: [ 25, 26, 27 ]
+        ac-version: [ 25, 26, 27, 28 ]
 
     steps:
       - name: Checkout the submodule


### PR DESCRIPTION
Commit GRAPHISOFT/archicad-addon-cmake-tools@fc168fe (Update the APIDevKitLInks.json for Archicad 28 Tech Preview., 2024-07-09) added AC28 to the known list of devkits, but the addon template was never updated to also test using that devkit.