### PR TITLE
Add precompiled header and default language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,4 +22,7 @@ set (AC_ADDON_FOR_DISTRIBUTION OFF CACHE BOOL "")
 
 set (AddOnSourcesFolder Src)
 set (AddOnResourcesFolder .)
-GenerateAddOnProject (CMakeTarget ${AC_VERSION} "${AC_API_DEVKIT_DIR}" ${AddOnSourcesFolder} ${AddOnResourcesFolder} ${AC_ADDON_LANGUAGE} ${addOnDefaultLanguage})
+
+set(PCH_HEADER "Src/ExamplePrecompiledHeader.hpp")
+
+GenerateAddOnProject (CMakeTarget ${AC_VERSION} "${AC_API_DEVKIT_DIR}" ${AddOnSourcesFolder} ${AddOnResourcesFolder} ${AC_ADDON_LANGUAGE} ${addOnDefaultLanguage} ${PCH_HEADER})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,8 @@ message (STATUS "Archicad Version: ${AC_VERSION}")
 SetGlobalCompilerDefinitions (${AC_VERSION})
 
 ReadConfigJson ()
-set (AC_ADDON_LANGUAGE "${addOnDefaultLanguage}" CACHE STRING "Add-On language code.")
+list(GET addOnLanguages 0 AC_ADDON_LANGUAGE) # 0 means the value "INT" of "languages" in config.json
+set(AC_ADDON_LANGUAGE "${AC_ADDON_LANGUAGE}" CACHE STRING "Add-On language code.")
 
 project (${addOnName}-${AC_VERSION})
 
@@ -21,4 +22,4 @@ set (AC_ADDON_FOR_DISTRIBUTION OFF CACHE BOOL "")
 
 set (AddOnSourcesFolder Src)
 set (AddOnResourcesFolder .)
-GenerateAddOnProject (CMakeTarget ${AC_VERSION} "${AC_API_DEVKIT_DIR}" ${AddOnSourcesFolder} ${AddOnResourcesFolder} ${AC_ADDON_LANGUAGE})
+GenerateAddOnProject (CMakeTarget ${AC_VERSION} "${AC_API_DEVKIT_DIR}" ${AddOnSourcesFolder} ${AddOnResourcesFolder} ${AC_ADDON_LANGUAGE} ${addOnDefaultLanguage})

--- a/Src/ExamplePrecompiledHeader.hpp
+++ b/Src/ExamplePrecompiledHeader.hpp
@@ -1,0 +1,27 @@
+#ifndef GS_FAVORITE_CONVERTER_PRECOMPILED_HEADER_HPP
+#define GS_FAVORITE_CONVERTER_PRECOMPILED_HEADER_HPP
+
+#include <GSNew.hpp>
+#include <GSMalloc.hpp>
+
+#include <limits.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <memory>
+
+#if defined(WINDOWS)
+#include "Win32Interface.hpp"
+#endif
+
+#include "APIEnvir.h"
+#include "ACAPinc.h"
+
+GS_UNHANDLED_ENUM_VALUE_CHECK_ON
+
+#endif // GS_FAVORITE_CONVERTER_PRECOMPILED_HEADER_HPP


### PR DESCRIPTION
We have added the precompiled header option to the Tools/CMakeCommon.cmake, so we added here an example. Meanwhile, the default language parameter was introduced too, therefore we added it too. To avoid the misunderstanding, from now, we use the languages first element from the config.json to set the current language of the add-on.